### PR TITLE
example correctness

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Basic Usage
         async with asyncwebsockets.open_websocket("wss://echo.websocket.org") as ws:
             await ws.send("test")
             evt = await ws.next_event()
-            print(evt.data)
+            print(type(evt), getattr(evt, 'data', None))
 
 
     multio.init("curio")


### PR DESCRIPTION
technically the received event could be a ping, etc. which will not have `data`

to reduce surprises, it might make sense to have next_event() ignore non-data events default