### PR TITLE
websocket: fix IndexError when no subprotocols

### DIFF
--- a/asyncwebsockets/websocket.py
+++ b/asyncwebsockets/websocket.py
@@ -102,7 +102,8 @@ class Websocket:
                 elif isinstance(msg, str):
                     msg = AcceptConnection(subprotocol=msg)
             if not msg:
-                msg = AcceptConnection(subprotocol=event.subprotocols[0])
+                subprotocol = event.subprotocols[0] if event.subprotocols else None
+                msg = AcceptConnection(subprotocol=subprotocol)
             data = self._connection.send(msg)
             await self._sock.send_all(data)
             if not isinstance(msg, AcceptConnection):


### PR DESCRIPTION
It is possible to get an empty list of subprotocols from a client (e.g. from Chrome on Android). In this case, we get an indexError because event.subprotocols is a list with length 0.

This adds an extra check for the case of the empty list. We use the value `None` if the list is empty since `handshake.H1Handshake._accept` checks for this value later.